### PR TITLE
Build Android App Bundle when a tag is pushed

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,6 @@
+TENANT=test
+CLIENT_ID=test
+SCOPE=test
+POLICY=test
+TOKEN_IDENTIFIER=test
+NONCE=test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: Build Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup the flutter environment.
+      uses: subosito/flutter-action@v1
+      with:
+        flutter-version: '1.22.4'
+    - name: Get flutter dependencies.
+      run: flutter pub get
+    - name: Build APK
+      run: flutter build appbundle --target-platform android-arm,android-arm64,android-x64
+    - name: Create Release
+      uses: actions/create-release@v1
+      id: create_release
+      with:
+        draft: false
+        prerelease: false
+        release_name: ${{ steps.version.outputs.version }}
+        tag_name: ${{ github.ref }}
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+    - name: Upload Android App Bundle Artifact
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./build/app/outputs/bundle/release/app-release.aab
+        asset_name: app-release.aab
+        asset_content_type: application/zip
+


### PR DESCRIPTION
Add GitHub Actions to build Android App Bundle and create a release when
a tag is pushed.